### PR TITLE
Fix leaky global variables.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ module.exports = function(options) {
   }
 
   var version = packagejson.version;
-  this.client_id = options.client_id;
-  this.client_secret = options.client_secret;
-  this.access_token = options.access_token;
+  var client_id = options.client_id;
+  var client_secret = options.client_secret;
+  var access_token = options.access_token;
 
   /**
    * Serializes an object into a parameter string
@@ -241,12 +241,12 @@ module.exports = function(options) {
   return {
 
     get access_token() {
-      return self.access_token;
+      return access_token;
     },
 
     set access_token(token) {
       if(typeof(token) === 'string') {
-        self.access_token = token;
+        access_token = token;
       }
     },
 


### PR DESCRIPTION
The readme describes creating a Jawbone "connection" using the following example:
```
var up = require('jawbone-up')(options);
``` 

When a connection is created in this way, the `this` object becomes the global object; as such, `this.access_token`, etc all leak into the global namespace. This PR addresses that bug.

It would be great if you could review and provide any feedback -- happy to make more updates/improvements upon your direction. It would be great to get this pushed to npm too if/when you're happy with it.