### PR TITLE
Modifying Heart Rate for API V1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,21 +166,12 @@ up.events.body.create(options, callback)              // POST /nudge/api/v.1.1/u
 up.events.body.delete({ xid : event_xid }, callback)  // DELETE /nudge/api/v.1.1/body_events/{event_xid}
 ```
 
-### Cardiac Metrics
+### Heart Rate
 
 ```javascript
-// get all cardiac events (paginated results)
-up.events.cardiac.get({}, callback)                      // GET /nudge/api/v.1.1/users/@me/cardiac_events
+// get all heart rates (paginated results)
+up.heartrates.get({}, callback)                      // GET /nudge/api/v.1.1/users/@me/heartrates
 
-// get a specific cardiac event
-up.events.cardiac.get({ xid : event_xid }, callback)     // GET /nudge/api/v.1.1/cardiac_events/{event_xid}
-
-// create a new cardiac event
-up.events.cardiac.create(options, callback)              // POST /nudge/api/v.1.1/users/@me/cardiac_events
-
-// delete a specific cardiac event
-up.events.cardiac.delete({ xid : event_xid }, callback)  // DELETE /nudge/api/v.1.1/cardiac_events/{event_xid}
-```
 
 ### Generic Events
 

--- a/index.js
+++ b/index.js
@@ -271,6 +271,9 @@ module.exports = function(options) {
       'delete': create_deletor('meals'),
       update: create_updater('meals')
     },
+    heartrates: {
+      get: create_getter_xid('heartrates')
+    },
     /** @class events */
     events: {
       /** @class events.body */
@@ -278,12 +281,6 @@ module.exports = function(options) {
         get: create_getter_xid('body_events'),
         create: create_creator('body_events'),
         'delete': create_deletor('body_events')
-      },
-      /** @class events.cardiac */
-      cardiac: {
-        get: create_getter_xid('cardiac_events'),
-        create: create_creator('cardiac_events'),
-        'delete': create_deletor('cardiac_events')
       },
       /** @class events.generic */
       generic: {


### PR DESCRIPTION
Hi,

The V1.1 does not use cardiac_events anymore. We should use

```
/nudge/api/v.1.1/users/@me/heartrates
```

instead of 

```
/nudge/api/v.1.0/users/@me/cardiac_events
```

Best Regard,

Takuto Suzuki
